### PR TITLE
docs: Add automated API docs generation and GitHub Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun run ci
+
+      - name: Build documentation
+        run: bun run docs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./docs"
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ dist
 tmp
 out-tsc
 
+# documentation
+docs
+
 # dependencies
 node_modules
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "lint-staged": "16.2.7",
         "nx": "22.2.2",
         "prettier": "3.7.4",
+        "typedoc": "0.28.15",
         "typescript": "5.9.3",
         "typescript-eslint": "8.49.0",
         "vite": "7.2.7",
@@ -411,6 +412,8 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
+    "@gerrit0/mini-shiki": ["@gerrit0/mini-shiki@3.20.0", "", { "dependencies": { "@shikijs/engine-oniguruma": "^3.20.0", "@shikijs/langs": "^3.20.0", "@shikijs/themes": "^3.20.0", "@shikijs/types": "^3.20.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-Wa57i+bMpK6PGJZ1f2myxo3iO+K/kZikcyvH8NIqNNZhQUbDav7V9LQmWOXhf946mz5c1NZ19WMsGYiDKTryzQ=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -583,6 +586,16 @@
 
     "@rushstack/ts-command-line": ["@rushstack/ts-command-line@5.1.5", "", { "dependencies": { "@rushstack/terminal": "0.19.5", "@types/argparse": "1.0.38", "argparse": "~1.0.9", "string-argv": "~0.3.1" } }, "sha512-YmrFTFUdHXblYSa+Xc9OO9FsL/XFcckZy0ycQ6q7VSBsVs5P0uD9vcges5Q9vctGlVdu27w+Ct6IuJ458V0cTQ=="],
 
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.20.0", "", { "dependencies": { "@shikijs/types": "3.20.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-Yx3gy7xLzM0ZOjqoxciHjA7dAt5tyzJE3L4uQoM83agahy+PlW244XJSrmJRSBvGYELDhYXPacD4R/cauV5bzQ=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.20.0", "", { "dependencies": { "@shikijs/types": "3.20.0" } }, "sha512-le+bssCxcSHrygCWuOrYJHvjus6zhQ2K7q/0mgjiffRbkhM4o1EWu2m+29l0yEsHDbWaWPNnDUTRVVBvBBeKaA=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.20.0", "", { "dependencies": { "@shikijs/types": "3.20.0" } }, "sha512-U1NSU7Sl26Q7ErRvJUouArxfM2euWqq1xaSrbqMu2iqa+tSp0D1Yah8216sDYbdDHw4C8b75UpE65eWorm2erQ=="],
+
+    "@shikijs/types": ["@shikijs/types@3.20.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-lhYAATn10nkZcBQ0BlzSbJA3wcmL5MXUUF8d2Zzon6saZDlToKaiRX60n2+ZaHJCmXEcZRWNzn+k9vplr8Jhsw=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@sinclair/typebox": ["@sinclair/typebox@0.34.41", "", {}, "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.2.5", "", { "dependencies": { "@smithy/types": "^4.9.0", "tslib": "^2.6.2" } }, "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA=="],
@@ -733,6 +746,8 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
@@ -740,6 +755,8 @@
     "@types/node": ["@types/node@24.10.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-gqkrWUsS8hcm0r44yn7/xZeV1ERva/nLgrLxFRUGb7aoNMIJfZJ3AC261zDQuOAKC7MiXai1WCpYc48jAHoShQ=="],
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.49.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.49.0", "@typescript-eslint/type-utils": "8.49.0", "@typescript-eslint/utils": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.49.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A=="],
 
@@ -1283,6 +1300,8 @@
 
     "lines-and-columns": ["lines-and-columns@2.0.3", "", {}, "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w=="],
 
+    "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
+
     "lint-staged": ["lint-staged@16.2.7", "", { "dependencies": { "commander": "^14.0.2", "listr2": "^9.0.5", "micromatch": "^4.0.8", "nano-spawn": "^2.0.0", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow=="],
 
     "listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
@@ -1303,13 +1322,19 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magicast": ["magicast@0.5.1", "", { "dependencies": { "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "source-map-js": "^1.2.1" } }, "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw=="],
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
+    "markdown-it": ["markdown-it@14.1.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
@@ -1422,6 +1447,8 @@
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
@@ -1575,9 +1602,13 @@
 
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
 
+    "typedoc": ["typedoc@0.28.15", "", { "dependencies": { "@gerrit0/mini-shiki": "^3.17.0", "lunr": "^2.3.9", "markdown-it": "^14.1.0", "minimatch": "^9.0.5", "yaml": "^2.8.1" }, "peerDependencies": { "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x" }, "bin": { "typedoc": "bin/typedoc" } }, "sha512-mw2/2vTL7MlT+BVo43lOsufkkd2CJO4zeOSuWQQsiXoV2VuEn7f6IZp2jsUDPmBMABpgR0R5jlcJ2OGEFYmkyg=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "typescript-eslint": ["typescript-eslint@8.49.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.49.0", "@typescript-eslint/parser": "8.49.0", "@typescript-eslint/typescript-estree": "8.49.0", "@typescript-eslint/utils": "8.49.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg=="],
+
+    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
@@ -1805,6 +1836,8 @@
 
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "typedoc/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
     "vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "vitest/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -1862,6 +1895,8 @@
     "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "nx/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "typedoc/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "vitest/vite/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,16 @@
   "license": "MIT",
   "author": "sudokar",
   "scripts": {
+    "ci": "bun install --frozen-lockfile",
     "prepare": "husky",
-    "prepublishOnly": "HUSKY=0"
+    "prepublishOnly": "HUSKY=0",
+    "lint": "nx lint",
+    "lint:fix": "nx lint --fix",
+    "test": "nx test",
+    "build": "nx build",
+    "docs": "typedoc && touch docs/.nojekyll",
+    "docs:watch": "typedoc --watch",
+    "docs:serve": "bun run docs && bunx http-server docs -o"
   },
   "nx": {
     "includedScripts": []
@@ -61,6 +69,7 @@
     "lint-staged": "16.2.7",
     "nx": "22.2.2",
     "prettier": "3.7.4",
+    "typedoc": "0.28.15",
     "typescript": "5.9.3",
     "typescript-eslint": "8.49.0",
     "vite": "7.2.7",

--- a/project.json
+++ b/project.json
@@ -24,6 +24,10 @@
         "passWithNoTests": false,
         "reportsDirectory": "./coverage/aws-sdk-vitest-mock"
       }
+    },
+    "docs": {
+      "command": "typedoc",
+      "outputs": ["{projectRoot}/docs"]
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,51 @@
-export * from './lib/mock-client.js';
-export { matchers } from './lib/matchers.js';
+/**
+ * AWS SDK Vitest Mock - A powerful, type-safe mocking library for AWS SDK v3 with Vitest
+ *
+ * @packageDocumentation
+ *
+ * @example Basic Setup
+ * ```typescript
+ * import { mockClient } from 'aws-sdk-vitest-mock';
+ * import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+ *
+ * const s3Mock = mockClient(S3Client);
+ * s3Mock.on(GetObjectCommand).resolves({ Body: 'file contents' });
+ *
+ * const client = new S3Client({});
+ * const result = await client.send(new GetObjectCommand({ Bucket: 'test', Key: 'file.txt' }));
+ * ```
+ *
+ * @example Using Matchers
+ * ```typescript
+ * import { expect } from 'vitest';
+ * import { matchers } from 'aws-sdk-vitest-mock';
+ *
+ * expect.extend(matchers);
+ *
+ * expect(s3Mock).toHaveReceivedCommand(GetObjectCommand);
+ * ```
+ */
+
+/**
+ * Core Functions for mocking AWS SDK clients
+ * @category Core Functions
+ */
+export { mockClient, mockClientInstance } from "./lib/mock-client.js";
+
+/**
+ * Command stub interface for configuring mock behaviors
+ * @category Command Stub
+ */
+export type { AwsCommandStub, AwsClientStub } from "./lib/mock-client.js";
+
+/**
+ * Custom Vitest matchers for AWS SDK assertions
+ * @category Matchers
+ */
+export { matchers } from "./lib/matchers.js";
+
+/**
+ * TypeScript types for matcher interfaces
+ * @category Matchers
+ */
+export type { AwsSdkMatchers } from "./lib/matchers.js";

--- a/src/lib/matchers.ts
+++ b/src/lib/matchers.ts
@@ -28,7 +28,37 @@ const getCommandCalls = (stub: AwsClientStub): ReceivedCall[] => {
   );
 };
 
+/**
+ * Custom Vitest matchers for asserting AWS SDK command calls.
+ *
+ * @category Matchers
+ *
+ * @example Setup matchers in your test setup file
+ * ```typescript
+ * import { expect } from 'vitest';
+ * import { matchers } from 'aws-sdk-vitest-mock';
+ *
+ * expect.extend(matchers);
+ * ```
+ */
 export const matchers = {
+  /**
+   * Assert that a command was received at least once.
+   *
+   * @param received - The AWS client stub
+   * @param command - The command constructor to check for
+   * @returns Matcher result
+   *
+   * @example
+   * ```typescript
+   * const s3Mock = mockClient(S3Client);
+   * const client = new S3Client({});
+   *
+   * await client.send(new GetObjectCommand({ Bucket: 'test', Key: 'file.txt' }));
+   *
+   * expect(s3Mock).toHaveReceivedCommand(GetObjectCommand);
+   * ```
+   */
   toHaveReceivedCommand<TInput extends object, TOutput extends MetadataBearer>(
     received: AwsClientStub,
     command: CommandConstructor<TInput, TOutput>,
@@ -58,6 +88,25 @@ export const matchers = {
     };
   },
 
+  /**
+   * Assert that a command was received exactly N times.
+   *
+   * @param received - The AWS client stub
+   * @param command - The command constructor to check for
+   * @param times - The exact number of times the command should have been received
+   * @returns Matcher result
+   *
+   * @example
+   * ```typescript
+   * const s3Mock = mockClient(S3Client);
+   * const client = new S3Client({});
+   *
+   * await client.send(new GetObjectCommand({ Bucket: 'test', Key: 'file1.txt' }));
+   * await client.send(new GetObjectCommand({ Bucket: 'test', Key: 'file2.txt' }));
+   *
+   * expect(s3Mock).toHaveReceivedCommandTimes(GetObjectCommand, 2);
+   * ```
+   */
   toHaveReceivedCommandTimes<
     TInput extends object,
     TOutput extends MetadataBearer,
@@ -81,6 +130,27 @@ export const matchers = {
     };
   },
 
+  /**
+   * Assert that a command was received with specific input parameters.
+   *
+   * @param received - The AWS client stub
+   * @param command - The command constructor to check for
+   * @param input - The expected input parameters
+   * @returns Matcher result
+   *
+   * @example
+   * ```typescript
+   * const s3Mock = mockClient(S3Client);
+   * const client = new S3Client({});
+   *
+   * await client.send(new GetObjectCommand({ Bucket: 'test', Key: 'file.txt' }));
+   *
+   * expect(s3Mock).toHaveReceivedCommandWith(GetObjectCommand, {
+   *   Bucket: 'test',
+   *   Key: 'file.txt'
+   * });
+   * ```
+   */
   toHaveReceivedCommandWith<
     TInput extends object,
     TOutput extends MetadataBearer,
@@ -132,6 +202,29 @@ export const matchers = {
     };
   },
 
+  /**
+   * Assert that the Nth command call was a specific command with specific input.
+   *
+   * @param received - The AWS client stub
+   * @param n - The call number (1-indexed)
+   * @param command - The command constructor to check for
+   * @param input - The expected input parameters
+   * @returns Matcher result
+   *
+   * @example
+   * ```typescript
+   * const s3Mock = mockClient(S3Client);
+   * const client = new S3Client({});
+   *
+   * await client.send(new PutObjectCommand({ Bucket: 'test', Key: 'file1.txt' }));
+   * await client.send(new GetObjectCommand({ Bucket: 'test', Key: 'file2.txt' }));
+   *
+   * expect(s3Mock).toHaveReceivedNthCommandWith(2, GetObjectCommand, {
+   *   Bucket: 'test',
+   *   Key: 'file2.txt'
+   * });
+   * ```
+   */
   toHaveReceivedNthCommandWith<
     TInput extends object,
     TOutput extends MetadataBearer,
@@ -192,6 +285,24 @@ export const matchers = {
     };
   },
 
+  /**
+   * Assert that no commands other than the expected ones were received.
+   *
+   * @param received - The AWS client stub
+   * @param expectedCommands - Array of command constructors that are allowed
+   * @returns Matcher result
+   *
+   * @example
+   * ```typescript
+   * const s3Mock = mockClient(S3Client);
+   * const client = new S3Client({});
+   *
+   * await client.send(new GetObjectCommand({ Bucket: 'test', Key: 'file.txt' }));
+   * await client.send(new GetObjectCommand({ Bucket: 'test', Key: 'other.txt' }));
+   *
+   * expect(s3Mock).toHaveReceivedNoOtherCommands([GetObjectCommand]);
+   * ```
+   */
   toHaveReceivedNoOtherCommands<
     TInput extends object,
     TOutput extends MetadataBearer,
@@ -227,10 +338,26 @@ export const matchers = {
   },
 };
 
+/**
+ * TypeScript interface for AWS SDK Vitest matchers.
+ * This interface is used to extend Vitest's assertion types.
+ *
+ * @category Matchers
+ */
 export interface AwsSdkMatchers<R = unknown> {
+  /**
+   * Assert that a command was received at least once.
+   * @param command - The command constructor to check for
+   */
   toHaveReceivedCommand<TInput extends object, TOutput extends MetadataBearer>(
     command: CommandConstructor<TInput, TOutput>,
   ): R;
+
+  /**
+   * Assert that a command was received exactly N times.
+   * @param command - The command constructor to check for
+   * @param times - The exact number of times
+   */
   toHaveReceivedCommandTimes<
     TInput extends object,
     TOutput extends MetadataBearer,
@@ -238,6 +365,12 @@ export interface AwsSdkMatchers<R = unknown> {
     command: CommandConstructor<TInput, TOutput>,
     times: number,
   ): R;
+
+  /**
+   * Assert that a command was received with specific input.
+   * @param command - The command constructor to check for
+   * @param input - The expected input parameters
+   */
   toHaveReceivedCommandWith<
     TInput extends object,
     TOutput extends MetadataBearer,
@@ -245,6 +378,13 @@ export interface AwsSdkMatchers<R = unknown> {
     command: CommandConstructor<TInput, TOutput>,
     input: TInput,
   ): R;
+
+  /**
+   * Assert that the Nth command call matches expectations.
+   * @param n - The call number (1-indexed)
+   * @param command - The command constructor to check for
+   * @param input - The expected input parameters
+   */
   toHaveReceivedNthCommandWith<
     TInput extends object,
     TOutput extends MetadataBearer,
@@ -254,6 +394,10 @@ export interface AwsSdkMatchers<R = unknown> {
     input: TInput,
   ): R;
 
+  /**
+   * Assert that only expected commands were received.
+   * @param expectedCommands - Array of allowed command constructors
+   */
   toHaveReceivedNoOtherCommands<
     TInput extends object,
     TOutput extends MetadataBearer,

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["./src/index.ts"],
+  "entryPointStrategy": "expand",
+  "out": "docs",
+  "plugin": [],
+  "exclude": [
+    "**/node_modules/**",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/test/**",
+    "**/tests/**",
+    "**/utils/**",
+    "**/lib/vitest-setup.ts"
+  ],
+  "excludePrivate": true,
+  "excludeProtected": false,
+  "excludeExternals": true,
+  "excludeInternal": true,
+  "readme": "./README.md",
+  "name": "AWS SDK Vitest Mock - API Reference",
+  "includeVersion": true,
+  "sort": ["source-order", "required-first"],
+  "navigation": {
+    "includeCategories": true,
+    "includeGroups": true
+  },
+  "categorizeByGroup": true,
+  "searchInComments": true,
+  "visibilityFilters": {
+    "protected": false,
+    "private": false,
+    "inherited": true,
+    "external": false
+  },
+  "theme": "default",
+  "githubPages": true,
+  "hideGenerator": false,
+  "excludeNotDocumented": false,
+  "validation": {
+    "notExported": true,
+    "invalidLink": true,
+    "notDocumented": false
+  },
+  "externalPattern": ["**/node_modules/**"],
+  "excludeReferences": true
+}


### PR DESCRIPTION
- Add TypeDoc config and docs scripts
- Document public API with JSDoc comments
- Add GitHub Actions workflow for docs deployment
- Update .gitignore for docs output
- Add docs target to project.json
- Add typedoc and related dependencies

# Summary

- Provide a concise description of the change.
- Call out any AWS SDK services or Vitest utilities affected.

## Related Issues

- Closes #

## Testing

List the commands you ran to verify the change (prefer Nx commands where available):

- [x] `bun run nx lint`
- [x] `bun run nx test`
- [x] `bun run nx build`

## Checklist

- [x] I have reviewed my changes for correctness and clarity.
- [ ] I have added or updated tests to cover these changes when appropriate.
- [x] I have updated documentation (README, or examples) if needed.
- [x] I have considered the impact on existing consumers of the library.

## Breaking Changes

- [x] No breaking changes.
- If breaking changes exist, describe the migration path:

## Additional Notes

Add any extra context for reviewers (logs, follow-up tasks, etc.).
