### PR TITLE
feat: Add global debug configuration for all mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,46 @@ s3Mock.restore();
 s3Mock.disableDebug();
 ```
 
+#### Global Debug Configuration
+
+Enable debug logging for all mocks globally, with the ability to override at the individual mock level:
+
+```typescript
+import { setGlobalDebug, mockClient } from "aws-sdk-vitest-mock";
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
+
+// Enable debug for all mocks
+setGlobalDebug(true);
+
+// All mocks will inherit the global debug setting
+const s3Mock = mockClient(S3Client);
+const dynamoMock = mockClient(DynamoDBClient);
+
+// Both mocks will log debug information
+s3Mock.on(GetObjectCommand).resolves({ Body: "data" });
+dynamoMock.on(GetItemCommand).resolves({ Item: { id: { S: "1" } } });
+
+// Override global setting for a specific mock
+s3Mock.disableDebug(); // This mock won't log, but dynamoMock still will
+
+// Disable global debug
+setGlobalDebug(false);
+```
+
+**Debug Priority (highest to lowest):**
+
+1. Individual mock's `enableDebug()` or `disableDebug()` call (explicit override)
+2. Global debug setting via `setGlobalDebug()`
+3. Default: disabled
+
+**Key behaviors:**
+
+- When global debug is enabled, all new and existing mocks will log unless explicitly disabled
+- Individual mock settings always take priority over global settings
+- `reset()` preserves individual debug settings
+- Global debug can be changed at any time and affects all mocks without explicit settings
+
 Debug mode provides comprehensive logging for:
 
 **Mock Configuration:**
@@ -664,14 +704,18 @@ Mocks an existing AWS SDK client instance.
 
 **Returns:** `AwsClientStub<TClient>`
 
+### Global Debug Functions
+
+- `setGlobalDebug(enabled: boolean)` - Enable or disable debug logging globally for all mocks
+
 ### `AwsClientStub` Methods
 
 - `on(Command, matcher?, options?)` - Configure mock for a command
 - `reset()` - Clear call history while preserving mock configurations
 - `restore()` - Restore original client behavior
 - `calls()` - Get call history
-- `enableDebug()` - Enable debug logging for troubleshooting
-- `disableDebug()` - Disable debug logging
+- `enableDebug()` - Enable debug logging for troubleshooting (overrides global setting)
+- `disableDebug()` - Disable debug logging (overrides global setting)
 
 ### `AwsCommandStub` Methods (Chainable)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,11 @@
  * Core Functions for mocking AWS SDK clients
  * @category Core Functions
  */
-export { mockClient, mockClientInstance } from "./lib/mock-client.js";
+export {
+  mockClient,
+  mockClientInstance,
+  setGlobalDebug,
+} from "./lib/mock-client.js";
 
 /**
  * Command stub interface for configuring mock behaviors

--- a/src/lib/mock-client-global-debug.test.ts
+++ b/src/lib/mock-client-global-debug.test.ts
@@ -1,0 +1,456 @@
+import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type Mock,
+} from "vitest";
+import {
+  mockClient,
+  mockClientInstance,
+  setGlobalDebug,
+} from "./mock-client.js";
+
+describe("Global Debug Configuration", () => {
+  let consoleSpy: Mock<typeof console.log>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => void 0);
+    // Reset global debug state before each test
+    setGlobalDebug(false);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    // Clean up global debug state
+    setGlobalDebug(false);
+  });
+
+  describe("setGlobalDebug", () => {
+    test("should not log when global debug is disabled by default", async () => {
+      const s3Mock = mockClient(S3Client);
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test" }));
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+
+    test("should enable global debug", async () => {
+      setGlobalDebug(true);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test" }));
+
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    test("should disable global debug", async () => {
+      setGlobalDebug(true);
+      setGlobalDebug(false);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test" }));
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Global debug with new mocks", () => {
+    test("should not log when global debug is disabled", async () => {
+      setGlobalDebug(false);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test" }));
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+
+    test("should log when global debug is enabled", async () => {
+      setGlobalDebug(true);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test" }));
+
+      expect(consoleSpy).toHaveBeenCalled();
+      const calls = consoleSpy.mock.calls.map((call) => String(call[0]));
+      const hasDebugLog = calls.some((call) =>
+        call.includes("aws-sdk-vitest-mock(debug):"),
+      );
+      expect(hasDebugLog).toBe(true);
+    });
+
+    test("should enable debug for multiple mocks when global debug is on", async () => {
+      setGlobalDebug(true);
+      const s3Mock = mockClient(S3Client);
+      const dynamoMock = mockClient(DynamoDBClient);
+
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+      dynamoMock.on(GetItemCommand).resolves({ Item: { id: { S: "1" } } });
+
+      const s3Client = new S3Client({});
+      const dynamoClient = new DynamoDBClient({});
+
+      await s3Client.send(
+        new GetObjectCommand({ Bucket: "test", Key: "test" }),
+      );
+      await dynamoClient.send(
+        new GetItemCommand({ TableName: "test", Key: { id: { S: "1" } } }),
+      );
+
+      expect(consoleSpy).toHaveBeenCalled();
+      const calls = consoleSpy.mock.calls.map((call) => String(call[0]));
+      const s3Logs = calls.filter((call) => call.includes("GetObjectCommand"));
+      const dynamoLogs = calls.filter((call) =>
+        call.includes("GetItemCommand"),
+      );
+
+      expect(s3Logs.length).toBeGreaterThan(0);
+      expect(dynamoLogs.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Individual mock debug overrides", () => {
+    test("should disable debug for individual mock when global is enabled", async () => {
+      setGlobalDebug(true);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.disableDebug();
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test" }));
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+
+    test("should enable debug for individual mock when global is disabled", async () => {
+      setGlobalDebug(false);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.enableDebug();
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test" }));
+
+      expect(consoleSpy).toHaveBeenCalled();
+      const calls = consoleSpy.mock.calls.map((call) => String(call[0]));
+      const hasDebugLog = calls.some((call) =>
+        call.includes("aws-sdk-vitest-mock(debug):"),
+      );
+      expect(hasDebugLog).toBe(true);
+    });
+
+    test("should respect individual overrides with multiple mocks", async () => {
+      setGlobalDebug(true);
+      const s3Mock = mockClient(S3Client);
+      const dynamoMock = mockClient(DynamoDBClient);
+
+      s3Mock.disableDebug(); // Explicitly disabled
+      // dynamoMock inherits global debug (enabled)
+
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+      dynamoMock.on(GetItemCommand).resolves({ Item: { id: { S: "1" } } });
+
+      const s3Client = new S3Client({});
+      const dynamoClient = new DynamoDBClient({});
+
+      consoleSpy.mockClear();
+      await s3Client.send(
+        new GetObjectCommand({ Bucket: "test", Key: "test" }),
+      );
+
+      // S3 should not log
+      const s3Calls = consoleSpy.mock.calls.filter((call) =>
+        String(call[0]).includes("GetObjectCommand"),
+      );
+      expect(s3Calls.length).toBe(0);
+
+      consoleSpy.mockClear();
+      await dynamoClient.send(
+        new GetItemCommand({ TableName: "test", Key: { id: { S: "1" } } }),
+      );
+
+      // DynamoDB should log
+      const dynamoCalls = consoleSpy.mock.calls.filter((call) =>
+        String(call[0]).includes("GetItemCommand"),
+      );
+      expect(dynamoCalls.length).toBeGreaterThan(0);
+    });
+
+    test("should allow enabling after disabling", async () => {
+      setGlobalDebug(false);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.disableDebug();
+      s3Mock.enableDebug(); // Should now be enabled
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test" }));
+
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    test("should allow disabling after enabling", async () => {
+      setGlobalDebug(true);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.enableDebug();
+      s3Mock.disableDebug(); // Should now be disabled
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test" }));
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Global debug state changes", () => {
+    test("should affect new commands after global debug is changed", async () => {
+      setGlobalDebug(false);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+
+      // First call - no debug
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test1" }));
+      expect(consoleSpy).not.toHaveBeenCalled();
+
+      // Enable global debug
+      setGlobalDebug(true);
+
+      // Second call - should have debug
+      consoleSpy.mockClear();
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test2" }));
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    test("should not affect mocks with explicit settings when global changes", async () => {
+      setGlobalDebug(false);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.enableDebug(); // Explicitly enabled
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+
+      // First call - debug enabled
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test1" }));
+      expect(consoleSpy).toHaveBeenCalled();
+
+      // Enable global debug (mock already explicitly enabled)
+      setGlobalDebug(true);
+      consoleSpy.mockClear();
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test2" }));
+      expect(consoleSpy).toHaveBeenCalled();
+
+      // Disable global debug (mock should still be enabled due to explicit setting)
+      setGlobalDebug(false);
+      consoleSpy.mockClear();
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test3" }));
+      expect(consoleSpy).toHaveBeenCalled(); // Still logging due to explicit setting
+    });
+  });
+
+  describe("Reset behavior", () => {
+    test("should preserve explicit debug setting after reset", async () => {
+      setGlobalDebug(false);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.enableDebug(); // Explicitly enabled
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test1" }));
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockClear();
+
+      s3Mock.reset();
+
+      // Should still log after reset
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test2" }));
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    test("should preserve global debug inheritance after reset", async () => {
+      setGlobalDebug(true);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test1" }));
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockClear();
+
+      s3Mock.reset();
+
+      // Should still inherit global debug
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test2" }));
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    test("should log reset operation when debug is enabled", () => {
+      setGlobalDebug(true);
+      const s3Mock = mockClient(S3Client);
+      consoleSpy.mockClear();
+
+      s3Mock.reset();
+
+      const calls = consoleSpy.mock.calls.map((call) => String(call[0]));
+      const resetLog = calls.find((call) =>
+        call.includes("Clearing call history"),
+      );
+      expect(resetLog).toBeDefined();
+    });
+
+    test("should not log reset operation when debug is disabled", () => {
+      setGlobalDebug(false);
+      const s3Mock = mockClient(S3Client);
+      consoleSpy.mockClear();
+
+      s3Mock.reset();
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Restore behavior", () => {
+    test("should log restore operation when debug is enabled", () => {
+      setGlobalDebug(true);
+      const s3Mock = mockClient(S3Client);
+      consoleSpy.mockClear();
+
+      s3Mock.restore();
+
+      const calls = consoleSpy.mock.calls.map((call) => String(call[0]));
+      const restoreLog = calls.find((call) =>
+        call.includes("Restoring original client behavior"),
+      );
+      expect(restoreLog).toBeDefined();
+    });
+
+    test("should not log restore operation when debug is disabled", () => {
+      setGlobalDebug(false);
+      const s3Mock = mockClient(S3Client);
+      consoleSpy.mockClear();
+
+      s3Mock.restore();
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mockClientInstance with global debug", () => {
+    test("should inherit global debug for client instances", async () => {
+      setGlobalDebug(true);
+      const client = new S3Client({});
+      const s3Mock = mockClientInstance(client);
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test" }));
+
+      expect(consoleSpy).toHaveBeenCalled();
+      const calls = consoleSpy.mock.calls.map((call) => String(call[0]));
+      const hasDebugLog = calls.some((call) =>
+        call.includes("aws-sdk-vitest-mock(debug):"),
+      );
+      expect(hasDebugLog).toBe(true);
+    });
+
+    test("should allow explicit override for client instances", async () => {
+      setGlobalDebug(true);
+      const client = new S3Client({});
+      const s3Mock = mockClientInstance(client);
+      s3Mock.disableDebug(); // Explicit override
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test" }));
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Mock configuration logging", () => {
+    test("should log mock configuration when global debug is enabled", () => {
+      setGlobalDebug(true);
+      const s3Mock = mockClient(S3Client);
+      consoleSpy.mockClear();
+
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const calls = consoleSpy.mock.calls.map((call) => String(call[0]));
+      const configLog = calls.find((call) => call.includes("Configured"));
+      expect(configLog).toBeDefined();
+    });
+
+    test("should not log mock configuration when global debug is disabled", () => {
+      setGlobalDebug(false);
+      const s3Mock = mockClient(S3Client);
+      consoleSpy.mockClear();
+
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+
+    test("should log mock configuration for explicit enable", () => {
+      setGlobalDebug(false);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.enableDebug();
+      consoleSpy.mockClear();
+
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const calls = consoleSpy.mock.calls.map((call) => String(call[0]));
+      const configLog = calls.find((call) => call.includes("Configured"));
+      expect(configLog).toBeDefined();
+    });
+  });
+
+  describe("Edge cases", () => {
+    test("should handle multiple enable/disable calls", async () => {
+      setGlobalDebug(false);
+      const s3Mock = mockClient(S3Client);
+      s3Mock.enableDebug();
+      s3Mock.disableDebug();
+      s3Mock.enableDebug();
+      s3Mock.on(GetObjectCommand).resolves({ Body: "test" });
+
+      const client = new S3Client({});
+      await client.send(new GetObjectCommand({ Bucket: "test", Key: "test" }));
+
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    test("should work correctly with no mocks configured", async () => {
+      setGlobalDebug(true);
+      mockClient(S3Client);
+
+      const client = new S3Client({});
+
+      await expect(
+        client.send(new GetObjectCommand({ Bucket: "test", Key: "test" })),
+      ).rejects.toThrow();
+
+      expect(consoleSpy).toHaveBeenCalled();
+      const calls = consoleSpy.mock.calls.map((call) => String(call[0]));
+      const noMockLog = calls.find((call) =>
+        call.includes("No mocks configured"),
+      );
+      expect(noMockLog).toBeDefined();
+    });
+  });
+});

--- a/src/lib/utils/debug-logger.test.ts
+++ b/src/lib/utils/debug-logger.test.ts
@@ -22,6 +22,14 @@ describe("debug-logger", () => {
     const logger: DebugLogger = createDebugLogger();
 
     expect(logger.enabled).toBe(false);
+    expect(logger.explicitlySet).toBe(false);
+  });
+
+  test("should create logger with initial enabled state", () => {
+    const logger: DebugLogger = createDebugLogger(true);
+
+    expect(logger.enabled).toBe(true);
+    expect(logger.explicitlySet).toBe(false);
   });
 
   test("should not log when disabled", () => {
@@ -68,5 +76,95 @@ describe("debug-logger", () => {
 
     logger.log("test message");
     expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  test("should set explicitlySet flag when enabling debug", () => {
+    const logger: DebugLogger = createDebugLogger();
+
+    expect(logger.explicitlySet).toBe(false);
+
+    enableDebug(logger);
+
+    expect(logger.enabled).toBe(true);
+    expect(logger.explicitlySet).toBe(true);
+  });
+
+  test("should set explicitlySet flag when disabling debug", () => {
+    const logger: DebugLogger = createDebugLogger(true);
+
+    expect(logger.explicitlySet).toBe(false);
+
+    disableDebug(logger);
+
+    expect(logger.enabled).toBe(false);
+    expect(logger.explicitlySet).toBe(true);
+  });
+
+  test("should keep explicitlySet flag after multiple enable/disable calls", () => {
+    const logger: DebugLogger = createDebugLogger();
+
+    enableDebug(logger);
+    expect(logger.explicitlySet).toBe(true);
+
+    disableDebug(logger);
+    expect(logger.explicitlySet).toBe(true);
+
+    enableDebug(logger);
+    expect(logger.explicitlySet).toBe(true);
+  });
+
+  describe("logDirect", () => {
+    test("should log directly without checking enabled flag", () => {
+      const logger: DebugLogger = createDebugLogger();
+
+      expect(logger.enabled).toBe(false);
+
+      logger.logDirect("test message");
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const call = consoleSpy.mock.calls[0]?.[0] as string;
+      expect(call).toContain("aws-sdk-vitest-mock(debug):");
+      expect(call).toContain("test message");
+    });
+
+    test("should log directly with data", () => {
+      const logger: DebugLogger = createDebugLogger();
+      const data = { key: "value" };
+
+      logger.logDirect("test message", data);
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const loggedMessage = (consoleSpy.mock.calls[0]?.[0] ?? "") as string;
+      expect(loggedMessage).toContain("aws-sdk-vitest-mock(debug):");
+      expect(loggedMessage).toContain("test message");
+      expect(loggedMessage).toContain('"key"');
+      expect(loggedMessage).toContain('"value"');
+    });
+
+    test("should log directly even when debug is disabled", () => {
+      const logger: DebugLogger = createDebugLogger();
+      disableDebug(logger);
+
+      expect(logger.enabled).toBe(false);
+
+      logger.logDirect("direct message");
+
+      expect(consoleSpy).toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const call = consoleSpy.mock.calls[0]?.[0] as string;
+      expect(call).toContain("direct message");
+    });
+
+    test("should log directly even when debug is enabled", () => {
+      const logger: DebugLogger = createDebugLogger();
+      enableDebug(logger);
+
+      logger.logDirect("direct message");
+
+      expect(consoleSpy).toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const call = consoleSpy.mock.calls[0]?.[0] as string;
+      expect(call).toContain("direct message");
+    });
   });
 });


### PR DESCRIPTION
# Summary

- Introduce setGlobalDebug to enable/disable debug globally
- Allow individual mocks to override global debug setting
- Update README with usage and priority details
- Add comprehensive tests for global debug behaviour

## Related Issues

- Closes #

## Checklist

- [ ] I have reviewed my changes for correctness and clarity.
- [ ] I have added or updated tests to cover these changes when appropriate.
- [ ] I have updated documentation (README, or examples) if needed.
- [ ] I have considered the impact on existing consumers of the library.

## Breaking Changes

- [ ] No breaking changes.
- If breaking changes exist, describe the migration path:

## Additional Notes

Add any extra context for reviewers (logs, follow-up tasks, etc.).
