### PR TITLE
fix: ESLint JSON parser config and minor code/test cleanup

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -5,6 +5,7 @@ import unicorn from "eslint-plugin-unicorn";
 import sonarjs from "eslint-plugin-sonarjs";
 import tseslint from "typescript-eslint";
 import vitest from "@vitest/eslint-plugin";
+import jsoncParser from "jsonc-eslint-parser";
 import { defineConfig } from "eslint/config";
 
 const unicornRecommendedRules =
@@ -112,6 +113,11 @@ export default defineConfig(
   },
   {
     files: ["**/*.json"],
+    languageOptions: {
+      // jsonc-eslint-parser is required for JSON files since @nx/eslint-plugin v22.6.3
+      // removed the JSON parser from flat/base — the parser must now be wired up explicitly.
+      parser: jsoncParser,
+    },
     rules: {
       "@nx/dependency-checks": "off",
     },

--- a/nx.json
+++ b/nx.json
@@ -32,17 +32,30 @@
     }
   },
   "plugins": [
-    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
+    {
+      "plugin": "@nx/eslint/plugin",
+      "options": {
+        "targetName": "lint"
+      }
+    },
     {
       "plugin": "@nx/vitest",
-      "options": { "testTargetName": "test", "ciTargetName": "test-ci" }
+      "options": {
+        "testTargetName": "test",
+        "ciTargetName": "test-ci"
+      }
     }
   ],
   "release": {
     "projects": ["aws-sdk-vitest-mock"],
-    "version": { "conventionalCommits": true },
+    "version": {
+      "conventionalCommits": true
+    },
     "changelog": {
-      "workspaceChangelog": { "createRelease": "github", "file": false }
+      "workspaceChangelog": {
+        "createRelease": "github",
+        "file": false
+      }
     },
     "releaseTag": {
       "pattern": "release/{version}"
@@ -50,5 +63,6 @@
     "git": {
       "commitMessage": "chore(release): {version}"
     }
-  }
+  },
+  "analytics": false
 }

--- a/src/lib/matchers.spec.ts
+++ b/src/lib/matchers.spec.ts
@@ -276,7 +276,7 @@ test("toHaveReceivedNoOtherCommands should pass when no other commands received"
     { equals: vi.fn() },
     mock,
     [GetItemCommand],
-  ) as MatcherResult;
+  );
 
   expect(result.pass).toBe(true);
   mock.restore();
@@ -300,7 +300,7 @@ test("toHaveReceivedNoOtherCommands should fail when unexpected commands receive
     { equals: vi.fn() },
     mock,
     [GetItemCommand],
-  ) as MatcherResult;
+  );
 
   expect(result.pass).toBe(false);
   expect(result.message()).toBe(
@@ -316,7 +316,7 @@ test("toHaveReceivedNoOtherCommands should pass with empty expected commands", (
     { equals: vi.fn() },
     mock,
     [],
-  ) as MatcherResult;
+  );
 
   expect(result.pass).toBe(true);
   mock.restore();

--- a/src/lib/mock-client-responses.spec.ts
+++ b/src/lib/mock-client-responses.spec.ts
@@ -10,6 +10,14 @@ import { expect, test, beforeEach, afterEach, describe } from "vitest";
 import { mockClient, AwsClientStub } from "./mock-client.js";
 import "./vitest-setup.js";
 
+const consumeStreamToBuffer = async (stream: Readable): Promise<Buffer> => {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk as Uint8Array);
+  }
+  return Buffer.concat(chunks);
+};
+
 describe("resolvesOnce / rejectsOnce", () => {
   let s3Mock: AwsClientStub<S3Client>;
 
@@ -342,15 +350,6 @@ describe("Stream Mocking", () => {
     const testData = Buffer.from("Binary content");
     s3Mock.on(GetObjectCommand).resolvesStream(testData);
 
-    // Helper to consume stream
-    const consumeStream = async (stream: Readable): Promise<Buffer> => {
-      const chunks: Uint8Array[] = [];
-      for await (const chunk of stream) {
-        chunks.push(chunk as Uint8Array);
-      }
-      return Buffer.concat(chunks);
-    };
-
     // Multiple calls should all work
     for (let callIndex = 0; callIndex < 3; callIndex++) {
       const result = await s3Client.send(
@@ -359,7 +358,7 @@ describe("Stream Mocking", () => {
           Key: "test-key",
         }),
       );
-      const content = await consumeStream(result.Body as Readable);
+      const content = await consumeStreamToBuffer(result.Body as Readable);
       expect(content.equals(testData)).toBe(true);
     }
   });
@@ -375,15 +374,7 @@ describe("Stream Mocking", () => {
       }),
     );
 
-    const consumeStream = async (stream: Readable): Promise<Buffer> => {
-      const chunks: Uint8Array[] = [];
-      for await (const chunk of stream) {
-        chunks.push(chunk as Uint8Array);
-      }
-      return Buffer.concat(chunks);
-    };
-
-    const content = await consumeStream(result.Body as Readable);
+    const content = await consumeStreamToBuffer(result.Body as Readable);
     expect(content.toString()).toBe("Hello");
   });
 

--- a/src/lib/mock-client.ts
+++ b/src/lib/mock-client.ts
@@ -183,7 +183,7 @@ function matchesPartial<T extends object>(
       typeof matcherValue === "object" &&
       !Array.isArray(matcherValue)
     ) {
-      if (typeof inputValue !== "object" || inputValue === null) {
+      if (!inputValue || typeof inputValue !== "object") {
         return false;
       }
       return matchesPartial(
@@ -203,9 +203,9 @@ function matchesStrict<T extends object>(
   if (input === (matcher as unknown as T)) return true;
   if (
     typeof input !== "object" ||
-    input === null ||
+    !input ||
     typeof matcher !== "object" ||
-    matcher === null
+    !matcher
   ) {
     return input === (matcher as unknown as T);
   }

--- a/src/lib/utils/stream-helpers.ts
+++ b/src/lib/utils/stream-helpers.ts
@@ -61,7 +61,7 @@ const createWebStream = (data: StreamInput): ReadableStream<Uint8Array> => {
  * Creates an appropriate stream for the current environment
  */
 export const createStream = (
-  data: StreamInput,
+  data: StreamInput | null | undefined,
 ): Readable | ReadableStream<Uint8Array> => {
   if (data === undefined || data === null) {
     throw new TypeError("data must be a string, Buffer, or Uint8Array");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,19 +12,15 @@
     "lib": ["es2020", "es2022.array", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    "baseUrl": ".",
-    "paths": {
-      "@aws-sdk-vitest-mock/source": ["src/index.ts"]
-    }
   },
   "files": [],
   "include": [],
   "references": [
     {
-      "path": "./tsconfig.lib.json"
+      "path": "./tsconfig.lib.json",
     },
     {
-      "path": "./tsconfig.spec.json"
-    }
-  ]
+      "path": "./tsconfig.spec.json",
+    },
+  ],
 }


### PR DESCRIPTION
- Explicitly set jsonc-eslint-parser for JSON files in ESLint config
- Format nx.json for consistency and add analytics: false
- Remove redundant type assertions in matcher tests
- Refactor stream consumer helper in mock-client-responses tests
- Simplify null checks in matcher and stream helpers
- Clean up tsconfig.json paths and formatting
