### PR TITLE
fix: restore chore releases and prevent partial GH releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,13 @@ jobs:
           else
             echo "release_required=true" >> "$GITHUB_OUTPUT"
           fi
-      - run: bun run nx release --skip-publish
+      - name: Build
+        run: bun run nx build
+      - name: Create GitHub release
         if: steps.release_check.outputs.release_required == 'true'
+        run: bun run nx release --skip-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - run: bun run nx build
       - name: Publish to npm
         if: steps.release_check.outputs.release_required == 'true'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,11 @@ jobs:
           else
             echo "release_required=true" >> "$GITHUB_OUTPUT"
           fi
-      - name: Build
-        run: bun run nx build
-      - name: Create GitHub release
+      - run: bun run nx release --skip-publish
         if: steps.release_check.outputs.release_required == 'true'
-        run: bun run nx release --skip-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - run: bun run nx build
       - name: Publish to npm
         if: steps.release_check.outputs.release_required == 'true'
         run: |

--- a/nx.json
+++ b/nx.json
@@ -46,6 +46,16 @@
   ],
   "release": {
     "projects": ["aws-sdk-vitest-mock"],
+    "conventionalCommits": {
+      "types": {
+        "chore": {
+          "semverBump": "patch",
+          "changelog": {
+            "title": "Chores"
+          }
+        }
+      }
+    },
     "version": {
       "conventionalCommits": true
     },


### PR DESCRIPTION
## Summary

- Restores patch releases for `chore` commits, which stopped triggering releases after Nx 22.6.4+ correctly excluded `chore` commits from version bumps per the conventional commits spec.
- All Dependabot PRs use `chore(deps-dev):` commit messages, so no release has fired since 1.0.63. Adding `conventionalCommits.types.chore` to `nx.json` maps these commits to a `patch` semver bump, restoring the original behavior.

## Related Issues

- Closes #

## Checklist

- [x] I have reviewed my changes for correctness and clarity.
- [x] No new tests needed (config-only change).
- [x] No documentation changes needed.
- [x] I have considered the impact on existing consumers of the library.

## Breaking Changes

- [x] No breaking changes.

## Additional Notes

This was part of commit `39bf5f7` that was inadvertently dropped when PR #245 was squash-merged.