### PR TITLE
feat: set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -20,57 +20,30 @@
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
     },
-    "@nx/vitest:test": {
-      "cache": true,
-      "inputs": ["default", "^production"]
-    },
-    "lint": {
-      "cache": true,
-      "inputs": ["default"]
-    }
+    "@nx/vitest:test": { "cache": true, "inputs": ["default", "^production"] },
+    "lint": { "cache": true, "inputs": ["default"] }
   },
   "plugins": [
-    {
-      "plugin": "nx-oxlint",
-      "options": {
-        "lintTargetName": "lint"
-      }
-    },
+    { "plugin": "nx-oxlint", "options": { "lintTargetName": "lint" } },
     {
       "plugin": "@nx/vitest",
-      "options": {
-        "testTargetName": "test",
-        "ciTargetName": "test-ci"
-      }
+      "options": { "testTargetName": "test", "ciTargetName": "test-ci" }
     }
   ],
   "release": {
     "projects": ["aws-sdk-vitest-mock"],
     "conventionalCommits": {
       "types": {
-        "chore": {
-          "semverBump": "patch",
-          "changelog": {
-            "title": "Chores"
-          }
-        }
+        "chore": { "semverBump": "patch", "changelog": { "title": "Chores" } }
       }
     },
-    "version": {
-      "conventionalCommits": true
-    },
+    "version": { "conventionalCommits": true },
     "changelog": {
-      "workspaceChangelog": {
-        "createRelease": "github",
-        "file": false
-      }
+      "workspaceChangelog": { "createRelease": "github", "file": false }
     },
-    "releaseTag": {
-      "pattern": "release/{version}"
-    },
-    "git": {
-      "commitMessage": "chore(release): {version}"
-    }
+    "releaseTag": { "pattern": "release/{version}" },
+    "git": { "commitMessage": "chore(release): {version}" }
   },
-  "analytics": false
+  "analytics": false,
+  "nxCloudId": "6a42eae2bb088ddf884122ba"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/64c1d01986505b508c52400d/workspaces/6a42eae2bb088ddf884122ba

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.