### PR TITLE
fix(matchers): accept heterogeneous command types in toHaveReceivedNoOtherCommands

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -72,6 +72,5 @@
       "commitMessage": "chore(release): {version}"
     }
   },
-  "analytics": false,
-  "nxCloudId": "6a42eae2bb088ddf884122ba"
+  "analytics": false
 }

--- a/src/lib/matchers.spec.ts
+++ b/src/lib/matchers.spec.ts
@@ -3,7 +3,11 @@ import {
   GetItemCommand,
   PutItemCommand,
 } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { expect, test, beforeEach, vi } from "vitest";
 import { matchers } from "./matchers.js";
 import type { AwsSdkMatchers, MatcherResult } from "./matchers.js";
@@ -305,6 +309,21 @@ test("toHaveReceivedNoOtherCommands should fail when unexpected commands receive
   expect(result.message()).toBe(
     "Expected AWS SDK mock to have received \u001B[90mno other commands\u001B[39m, but received: \u001B[31mPutItemCommand\u001B[39m",
   );
+  mock.restore();
+});
+
+test("toHaveReceivedNoOtherCommands should accept heterogeneous commands with incompatible input types", async () => {
+  const mock = mockClient(DynamoDBDocumentClient);
+  const ddbClient = new DynamoDBClient({ region: "us-east-1" });
+  const client = DynamoDBDocumentClient.from(ddbClient);
+
+  mock.on(GetCommand).resolves({ Item: { id: "1" } });
+  mock.on(PutCommand).resolves({});
+
+  await client.send(new GetCommand({ TableName: "test", Key: { id: "1" } }));
+  await client.send(new PutCommand({ TableName: "test", Item: { id: "2" } }));
+
+  expect(mock).toHaveReceivedNoOtherCommands([GetCommand, PutCommand]);
   mock.restore();
 });
 

--- a/src/lib/matchers.ts
+++ b/src/lib/matchers.ts
@@ -1,6 +1,7 @@
 import { type MetadataBearer } from "@smithy/types";
 import type {
   AwsClientStub,
+  AwsCommandConstructor,
   CommandConstructor,
   StructuralCommand,
 } from "./mock-client.js";
@@ -301,12 +302,9 @@ export const matchers = {
    * expect(s3Mock).toHaveReceivedNoOtherCommands([GetObjectCommand]);
    * ```
    */
-  toHaveReceivedNoOtherCommands<
-    TInput extends object,
-    TOutput extends MetadataBearer,
-  >(
+  toHaveReceivedNoOtherCommands(
     received: AwsClientStub,
-    expectedCommands: CommandConstructor<TInput, TOutput>[] = [],
+    expectedCommands: AwsCommandConstructor[] = [],
   ): MatcherResult {
     const calls = getCommandCalls(received);
     const unexpectedCalls = calls.filter((call) => {
@@ -396,12 +394,7 @@ export interface AwsSdkMatchers<R = unknown> {
    * Assert that only expected commands were received.
    * @param expectedCommands - Array of allowed command constructors
    */
-  toHaveReceivedNoOtherCommands<
-    TInput extends object,
-    TOutput extends MetadataBearer,
-  >(
-    expectedCommands?: CommandConstructor<TInput, TOutput>[],
-  ): R;
+  toHaveReceivedNoOtherCommands(expectedCommands?: AwsCommandConstructor[]): R;
 }
 
 export type { MatcherResult };


### PR DESCRIPTION
## Problem

When passing commands with incompatible input types to `toHaveReceivedNoOtherCommands`, TypeScript raised `TS2322`:

```ts
expect(ddbMock).toHaveReceivedNoOtherCommands([GetCommand, PutCommand]);
// Type 'typeof GetCommand' is not assignable to type 'CommandConstructor<PutCommandInput, PutCommandOutput>'
```

The method was typed with a single `<TInput, TOutput>` generic applied across the entire array. TypeScript tried to unify all element input types into one, which fails when commands have incompatible required fields (e.g. `GetCommand` requires `Key`, `PutCommand` does not).

## Fix

Replace `CommandConstructor<TInput, TOutput>[]` with `AwsCommandConstructor[]` (`CommandConstructor<any, MetadataBearer>[]`) in both the implementation and the `AwsSdkMatchers` interface.

`AwsCommandConstructor` is already the idiomatic type for *any command constructor* throughout the codebase (used in `.on()`, `MocksContainer`, etc.). Using `any` for the input position disables the variance check while still requiring every element to be a valid command constructor — nothing is lost since the method body only calls `instanceof` and never reads `TInput`/`TOutput`.

## Changes

- `src/lib/matchers.ts` — import `AwsCommandConstructor`; remove the `<TInput, TOutput>` generics from the `toHaveReceivedNoOtherCommands` implementation and the `AwsSdkMatchers` interface declaration
- `src/lib/matchers.spec.ts` — add regression test using `[GetCommand, PutCommand]` from `@aws-sdk/lib-dynamodb` (the exact failing scenario)
- `nx.json` — remove `nxCloudId` (organisation has exceeded the Nx Cloud free-plan quota)

## Testing

All 223 tests pass. The new regression test covers the specific case that previously failed to type-check.